### PR TITLE
Ensure record/replay state initialized at first paint

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -75,7 +75,7 @@ function platformTasks(platform) {
     [buildTask]
   );
 
-  return [buildTask, testTask];
+  return [buildTask, testStaticTask, testPlaywrightTask];
 }
 
 function getBranchName(refName) {

--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -63,19 +63,7 @@ function platformTasks(platform) {
     [buildTask]
   );
 
-  const testPlaywrightTask = newTask(
-    `Chromium Playwright Tests ${platform}`,
-    {
-      kind: "PlaywrightLiveTests",
-      runtime: "chromium",
-      revision: chromiumRevision,
-      driverRevision,
-    },
-    platform,
-    [buildTask]
-  );
-
-  return [buildTask, testStaticTask, testPlaywrightTask];
+  return [buildTask, testStaticTask];
 }
 
 function getBranchName(refName) {

--- a/build.js
+++ b/build.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const os = require("os");
 const { spawnSync } = require("child_process");
 
 if (currentPlatform() == "macOS") {
@@ -7,11 +6,16 @@ if (currentPlatform() == "macOS") {
   spawnChecked("touch", [`${__dirname}/chrome/app/chrome_exe_main_mac.cc`]);
 }
 
-// Download the latest record/replay driver.
-const driverArchive = `${currentPlatform()}-recordreplay.tgz`;
+// Download the record/replay driver archive, using the latest version unless
+// it was overridden via the environment.
+let driverArchive = `${currentPlatform()}-recordreplay.tgz`;
+let downloadArchive = driverArchive;
+if (process.env.DRIVER_REVISION) {
+  downloadArchive = `${currentPlatform()}-recordreplay-${process.env.DRIVER_REVISION}.tgz`;
+}
 const driverFile = `${currentPlatform()}-recordreplay.${driverExtension()}`;
 const driverJSON = `${currentPlatform()}-recordreplay.json`;
-spawnChecked("curl", [`https://static.replay.io/downloads/${driverArchive}`, "-o", driverArchive], { stdio: "inherit" });
+spawnChecked("curl", [`https://static.replay.io/downloads/${downloadArchive}`, "-o", driverArchive], { stdio: "inherit" });
 spawnChecked("tar", ["xf", driverArchive]);
 fs.unlinkSync(driverArchive);
 

--- a/components/viz/service/display/record_replay_render.cc
+++ b/components/viz/service/display/record_replay_render.cc
@@ -13,6 +13,10 @@
 #include "components/viz/service/display_embedder/software_output_surface.h"
 #include "ui/gfx/codec/jpeg_codec.h"
 
+namespace blink {
+extern void RecordReplayStateEnsureInitialized();
+}
+
 namespace viz {
 
 struct SharedBitmapInfo {
@@ -184,6 +188,10 @@ static std::atomic<size_t> gCurrentPaintBookmark;
 static size_t gLastCommitBookmark;
 
 void RecordReplayOnCommitPaint() {
+  // Record/replay state has to be initialized before the first paint
+  // starts, as a checkpoint must have been taken.
+  blink::RecordReplayStateEnsureInitialized();
+
   gCurrentPaintBookmark = V8RecordReplayPaintStart();
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -133,7 +133,8 @@ void LocalWindowProxy::DisposeContext(Lifecycle next_status,
   lifecycle_ = next_status;
 }
 
-static bool gHasContext;
+// Record/replay state is initialized along with the first LocalWindowProxy.
+static bool gRecordReplayStateInitialized;
 
 void LocalWindowProxy::Initialize() {
   TRACE_EVENT1("v8", "LocalWindowProxy::Initialize", "IsMainFrame",
@@ -186,8 +187,8 @@ void LocalWindowProxy::Initialize() {
   // After creating the first context, we are ready to set up the state used
   // to process driver commands when recording/replaying, and to create
   // checkpoints. Create the first checkpoint at which execution can pause.
-  if (recordreplay::IsRecordingOrReplaying() && !gHasContext) {
-    gHasContext = true;
+  if (recordreplay::IsRecordingOrReplaying() && !gRecordReplayStateInitialized) {
+    gRecordReplayStateInitialized = true;
     SetupRecordReplayCommands(GetIsolate());
     recordreplay::NewCheckpoint();
   }
@@ -596,6 +597,12 @@ void LocalWindowProxy::SetAbortScriptExecution(
 LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
                                    LocalFrame& frame,
                                    scoped_refptr<DOMWrapperWorld> world)
-    : WindowProxy(isolate, frame, std::move(world)) {}
+    : WindowProxy(isolate, frame, std::move(world)) {
+  // Eagerly initialize the first window proxy when recording/replaying so that
+  // this happens as early as possible and at a predictable point.
+  if (!gRecordReplayStateInitialized) {
+    Initialize();
+  }
+}
 
 }  // namespace blink

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -594,14 +594,23 @@ void LocalWindowProxy::SetAbortScriptExecution(
   script_state_->GetContext()->SetAbortScriptExecution(callback);
 }
 
+// We keep track of the most recently created local window proxy
+// for ensuring that record/replay state is initialized when
+// the first paint is triggered. FIXME clean up reference.
+static LocalWindowProxy* gLatestLocalWindowProxy;
+
 LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
                                    LocalFrame& frame,
                                    scoped_refptr<DOMWrapperWorld> world)
     : WindowProxy(isolate, frame, std::move(world)) {
-  // Eagerly initialize the first window proxy when recording/replaying so that
-  // this happens as early as possible and at a predictable point.
+  gLatestLocalWindowProxy = this;
+}
+
+void RecordReplayStateEnsureInitialized() {
   if (recordreplay::IsRecordingOrReplaying() && !gRecordReplayStateInitialized) {
-    Initialize();
+    CHECK(gLatestLocalWindowProxy);
+    gLatestLocalWindowProxy->InitializeIfNeeded();
+    CHECK(gRecordReplayStateInitialized);
   }
 }
 

--- a/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
+++ b/third_party/blink/renderer/bindings/core/v8/local_window_proxy.cc
@@ -600,7 +600,7 @@ LocalWindowProxy::LocalWindowProxy(v8::Isolate* isolate,
     : WindowProxy(isolate, frame, std::move(world)) {
   // Eagerly initialize the first window proxy when recording/replaying so that
   // this happens as early as possible and at a predictable point.
-  if (!gRecordReplayStateInitialized) {
+  if (recordreplay::IsRecordingOrReplaying() && !gRecordReplayStateInitialized) {
     Initialize();
   }
 }


### PR DESCRIPTION
This should fix https://github.com/RecordReplay/backend/issues/4799, though I need to test it first.